### PR TITLE
fix the double encoding

### DIFF
--- a/docs/pages/SIOPSelectCredential-SJOJQJR7.js
+++ b/docs/pages/SIOPSelectCredential-SJOJQJR7.js
@@ -65,7 +65,8 @@ window.MHR.register("SIOPSelectCredential", class SIOPSelectCredential extends w
 });
 async function sendCredential(backEndpoint, credential, state) {
   console.log("sending POST to:", backEndpoint + "?state=" + state);
-  let body = { "credential": credential };
+  var jsonCred = JSON.parse(credential)
+  let body = { "credential": jsonCred };
   try {
     let response = await fetch(backEndpoint + "?state=" + state, {
       method: "POST",


### PR DESCRIPTION
The current version takes the (json) string from the local storage and double encodes it, f.e. like:
```json
{ 
  "credential": "{\"my\":\"credential\"}"
}
```
Thats not proper json and makes the verifier api hard to use.  
The change does parse the string and then puts the credential in the json as an object:
```json
{ 
  "credential": {
      "my": "credential"
  }
}
```